### PR TITLE
Add AdaFruit gyro library as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/L3GD20HGyroLib"]
+	path = lib/L3GD20HGyroLib
+	url = https://github.com/Team4761/L3GD20HGyroLib

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: java
 
 install:
   - sh .travis-init.sh
+  - git submodule init
+  - git submodule update
 
 script:
   - ant compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 
-install: sh .travis-init.sh
+install:
+  - sh .travis-init.sh
+  - ant build-gyro-lib
 
 script: ant compile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: java
 
-install:
-  - sh .travis-init.sh
-  - git submodule init
-  - git submodule update
+install: sh .travis-init.sh
 
-script:
-  - ant compile
+script: ant compile
 
 jdk: oraclejdk8
 

--- a/build.properties
+++ b/build.properties
@@ -2,3 +2,4 @@
 package=org.robockets.steamworks
 robot.class=${package}.Robot
 simulation.world.file=/usr/share/frcsim/worlds/GearsBotDemo.world
+userLibs=lib/jar/

--- a/build.xml
+++ b/build.xml
@@ -29,7 +29,7 @@
   <target name="build-gyro-lib" depends="make-jar-directory">
     <!-- TODO: Only run if JAR file doesn't already exist -->
     <exec dir="./lib/L3GD20HGyroLib" executable="mvn">
-      <arg line="package" />
+      <arg line="package -B" />
     </exec>
     <copy file="./lib/L3GD20HGyroLib/target/L3GD20H-lib-1.0.jar" todir="./lib/jar"></copy>
   </target>

--- a/build.xml
+++ b/build.xml
@@ -21,6 +21,22 @@
 
   <!-- Any other property in build.properties can also be overridden. -->
 
+  <!-- 4761 -->
+  <target name="make-jar-directory">
+    <mkdir dir="./lib/jar"></mkdir>
+  </target>
+
+  <target name="build-gyro-lib" depends="make-jar-directory">
+    <!-- TODO: Only run if JAR file doesn't already exist -->
+    <exec dir="./lib/L3GD20HGyroLib" executable="mvn">
+      <arg line="package" />
+    </exec>
+    <copy file="./lib/L3GD20HGyroLib/target/L3GD20H-lib-1.0.jar" todir="./lib/jar"></copy>
+  </target>
+
+  <target name="compile" description="Compile source code" depends="build-gyro-lib, athena-project-build.compile"></target>
+
+  <!-- WPILib -->
   <property file="${user.home}/wpilib/wpilib.properties"/>
   <property file="build.properties"/>
   <property file="${user.home}/wpilib/java/${version}/ant/build.properties"/>

--- a/build.xml
+++ b/build.xml
@@ -33,9 +33,19 @@
         <echo>Gyro library already built, not recompiling</echo>
       </then>
       <else>
-        <exec dir="./lib/L3GD20HGyroLib" executable="mvn">
-          <arg line="package -B" />
-        </exec>
+        <if>
+          <os family="windows" />
+          <then>
+            <exec dir="./lib/L3GD20HGyroLib" executable="cmd">
+              <arg line="/c mvn package -B" />
+            </exec>
+          </then>
+          <else>
+            <exec dir="./lib/L3GD20HGyroLib" executable="mvn">
+              <arg line="package -B" />
+            </exec>
+          </else>
+        </if>
         <copy file="./lib/L3GD20HGyroLib/target/L3GD20H-lib-1.0.jar" todir="./lib/jar"></copy>
       </else>
     </if>

--- a/build.xml
+++ b/build.xml
@@ -27,11 +27,18 @@
   </target>
 
   <target name="build-gyro-lib" depends="make-jar-directory">
-    <!-- TODO: Only run if JAR file doesn't already exist -->
-    <exec dir="./lib/L3GD20HGyroLib" executable="mvn">
-      <arg line="package -B" />
-    </exec>
-    <copy file="./lib/L3GD20HGyroLib/target/L3GD20H-lib-1.0.jar" todir="./lib/jar"></copy>
+    <if>
+      <available file="./lib/jar/L3GD20H-lib-1.0.jar" />
+      <then>
+        <echo>Gyro library already built, not recompiling</echo>
+      </then>
+      <else>
+        <exec dir="./lib/L3GD20HGyroLib" executable="mvn">
+          <arg line="package -B" />
+        </exec>
+        <copy file="./lib/L3GD20HGyroLib/target/L3GD20H-lib-1.0.jar" todir="./lib/jar"></copy>
+      </else>
+    </if>
   </target>
 
   <target name="compile" description="Compile source code" depends="build-gyro-lib, athena-project-build.compile"></target>


### PR DESCRIPTION
Next up: Robockets-Commons!

I'll probably look into making this solution more DRY when I do that.

To get this repository:
1. `git clone ...`
2. `git submodule update --init --recursive`

The general flow that submodules libraries follow is:
1. Pull code with `git submodule update`
2. Build JAR
3. Copy JAR to lib/jar
4. The new `userLibs` property in the 2017 plugins now takes directories so we don't need to add the JAR files individually to build.properties.

P.S. step 4 means 2016-Robot-Code is now broken with the latest plugins. :tada: