### PR TITLE
Ball intake subsystem

### DIFF
--- a/src/org/robockets/steamworks/PortNumbers.java
+++ b/src/org/robockets/steamworks/PortNumbers.java
@@ -12,14 +12,16 @@ public class PortNumbers {
     public static final int SHOOTER_ROLLER_ENCODER_PORT_ONE = 8;
     public static final int SHOOTER_ROLLER_ENCODER_PORT_TWO = 9;
 
-    public static final int SHOOTER_CONVEYOR_SC_ONE = 5;
-    public static final int SHOOTER_CONVEYOR_SC_TWO = 6;
-
     public static final int DRIVETRAIN_FRONT_LEFT_SC_PORT = 0;
     public static final int DRIVETRAIN_FRONT_RIGHT_SC_PORT = 1;
     public static final int DRIVETRAIN_BACK_LEFT_SC_PORT = 2;
     public static final int DRIVETRAIN_BACK_RIGHT_SC_PORT = 3;
 
+    public static final int SHOOTER_CONVEYOR_SC_ONE = 5;
+    public static final int SHOOTER_CONVEYOR_SC_TWO = 6;
+    
+    public static final int BALL_INTAKE_ROLLER_SC_PORT = 7;
+    
     public static final int DRIVETRAIN_FRONT_LEFT_ENCODER_PORT_ONE = 0;
     public static final int DRIVETRAIN_FRONT_LEFT_ENCODER_PORT_TWO = 1;
     public static final int DRIVETRAIN_BACK_LEFT_ENCODER_PORT_ONE = 2;
@@ -31,5 +33,4 @@ public class PortNumbers {
 
     public static final int JOYSTICK_LEFT_STICK = 1;
     public static final int JOYSTICK_RIGHT_STICK = 4;
-
 }

--- a/src/org/robockets/steamworks/Robot.java
+++ b/src/org/robockets/steamworks/Robot.java
@@ -8,6 +8,7 @@ import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import org.robockets.steamworks.commands.GottaGoFast;
+import org.robockets.steamworks.subsystems.BallIntake;
 import org.robockets.steamworks.subsystems.Drivetrain;
 import org.robockets.steamworks.subsystems.Shooter;
 
@@ -22,6 +23,7 @@ public class Robot extends IterativeRobot {
 
 	public static OI oi;
 
+	public static BallIntake ballIntake;
 	public static Drivetrain drivetrain;
 	public static Shooter shooter;
 
@@ -36,8 +38,11 @@ public class Robot extends IterativeRobot {
 	@Override
 	public void robotInit() {
 		oi = new OI();
+		
+		ballIntake = new BallIntake();
 		drivetrain = new Drivetrain();
 		shooter = new Shooter();
+
 		// chooser.addObject("My Auto", new MyAutoCommand());
 		SmartDashboard.putData("Auto mode", chooser);
 

--- a/src/org/robockets/steamworks/RobotMap.java
+++ b/src/org/robockets/steamworks/RobotMap.java
@@ -2,6 +2,7 @@ package org.robockets.steamworks;
 
 import edu.wpi.first.wpilibj.Encoder;
 import edu.wpi.first.wpilibj.RobotDrive;
+import edu.wpi.first.wpilibj.SpeedController;
 import edu.wpi.first.wpilibj.TalonSRX;
 
 /**
@@ -18,6 +19,8 @@ public class RobotMap {
 
     public static TalonSRX conveyorSpeedControllerOne = new TalonSRX(PortNumbers.SHOOTER_CONVEYOR_SC_ONE);
     public static TalonSRX conveyorSpeedControllerTwo = new TalonSRX(PortNumbers.SHOOTER_CONVEYOR_SC_TWO);
+    
+    public static TalonSRX ballIntakeRoller = new TalonSRX(PortNumbers.BALL_INTAKE_ROLLER_SC_PORT);
 
     // TODO: Add breakbeam sensor
 

--- a/src/org/robockets/steamworks/RobotMap.java
+++ b/src/org/robockets/steamworks/RobotMap.java
@@ -2,7 +2,6 @@ package org.robockets.steamworks;
 
 import edu.wpi.first.wpilibj.Encoder;
 import edu.wpi.first.wpilibj.RobotDrive;
-import edu.wpi.first.wpilibj.SpeedController;
 import edu.wpi.first.wpilibj.TalonSRX;
 
 /**

--- a/src/org/robockets/steamworks/subsystems/BallIntake.java
+++ b/src/org/robockets/steamworks/subsystems/BallIntake.java
@@ -6,6 +6,7 @@ import edu.wpi.first.wpilibj.command.Subsystem;
 
 /**
  * Rollers for taking in balls.
+ * @author Simon Andrews
  */
 public class BallIntake extends Subsystem {
 	private boolean isEnabled = false;
@@ -18,12 +19,14 @@ public class BallIntake extends Subsystem {
     public void spinRollers(double speed) {
     	if(isEnabled == false) {
     		RobotMap.ballIntakeRoller.set(speed);
+    		isEnabled = true;
     	}
     }
     
     public void stopRollers() {
     	if(isEnabled == true) {
     		RobotMap.ballIntakeRoller.stopMotor();
+    		isEnabled = false;
     	}
     }
     

--- a/src/org/robockets/steamworks/subsystems/BallIntake.java
+++ b/src/org/robockets/steamworks/subsystems/BallIntake.java
@@ -1,0 +1,34 @@
+package org.robockets.steamworks.subsystems;
+
+import org.robockets.steamworks.RobotMap;
+
+import edu.wpi.first.wpilibj.command.Subsystem;
+
+/**
+ * Rollers for taking in balls.
+ */
+public class BallIntake extends Subsystem {
+	private boolean isEnabled = false;
+	
+    public void initDefaultCommand() {
+        // Set the default command for a subsystem here.
+        //setDefaultCommand(new MySpecialCommand());
+    }
+    
+    public void spinRollers(double speed) {
+    	if(isEnabled == false) {
+    		RobotMap.ballIntakeRoller.set(speed);
+    	}
+    }
+    
+    public void stopRollers() {
+    	if(isEnabled == true) {
+    		RobotMap.ballIntakeRoller.stopMotor();
+    	}
+    }
+    
+    public boolean isEnabled() {
+    	return isEnabled;
+    }
+}
+


### PR DESCRIPTION
I'm working on getting the Talon SRX CAN library working and the `BallIntake` subsystem got lost in the clutter the first time around. Oops! :flushed: