### PR TITLE
Add new Climber subsystem and Climb command.

### DIFF
--- a/src/org/robockets/steamworks/PortNumbers.java
+++ b/src/org/robockets/steamworks/PortNumbers.java
@@ -32,4 +32,6 @@ public class PortNumbers {
     public static final int JOYSTICK_LEFT_STICK = 1;
     public static final int JOYSTICK_RIGHT_STICK = 4;
 
+    public static final int CLIMBER_SC_PORT = 7;
+    public static final int CLIMBER_PDP_PORT = 1; // On the PDP what channel is the climber motor (this is separate from PWM channels).
 }

--- a/src/org/robockets/steamworks/Robot.java
+++ b/src/org/robockets/steamworks/Robot.java
@@ -7,6 +7,8 @@ import edu.wpi.first.wpilibj.command.Scheduler;
 import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
+import org.robockets.steamworks.commands.Climb;
 import org.robockets.steamworks.commands.GottaGoFast;
 import org.robockets.steamworks.subsystems.Climber;
 import org.robockets.steamworks.subsystems.Drivetrain;
@@ -29,6 +31,7 @@ public class Robot extends IterativeRobot {
 
 	private Command autonomousCommand;
 	private Command drive;
+	private Command climb;
 	private SendableChooser chooser = new SendableChooser();
 
 	/**
@@ -42,9 +45,14 @@ public class Robot extends IterativeRobot {
 		shooter = new Shooter();
 		climber = new Climber();
 		// chooser.addObject("My Auto", new MyAutoCommand());
-		SmartDashboard.putData("Auto mode", chooser);
-
 		drive = new GottaGoFast(0.5);
+		climb = new Climb(0.5);
+		
+		SmartDashboard.putData("Auto mode", chooser);
+		SmartDashboard.putData(new Climb(0.5));
+
+		
+		
 	}
 
 	/**

--- a/src/org/robockets/steamworks/Robot.java
+++ b/src/org/robockets/steamworks/Robot.java
@@ -8,6 +8,7 @@ import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import org.robockets.steamworks.commands.GottaGoFast;
+import org.robockets.steamworks.subsystems.Climber;
 import org.robockets.steamworks.subsystems.Drivetrain;
 import org.robockets.steamworks.subsystems.Shooter;
 
@@ -24,6 +25,7 @@ public class Robot extends IterativeRobot {
 
 	public static Drivetrain drivetrain;
 	public static Shooter shooter;
+	public static Climber climber;
 
 	private Command autonomousCommand;
 	private Command drive;
@@ -38,6 +40,7 @@ public class Robot extends IterativeRobot {
 		oi = new OI();
 		drivetrain = new Drivetrain();
 		shooter = new Shooter();
+		climber = new Climber();
 		// chooser.addObject("My Auto", new MyAutoCommand());
 		SmartDashboard.putData("Auto mode", chooser);
 

--- a/src/org/robockets/steamworks/Robot.java
+++ b/src/org/robockets/steamworks/Robot.java
@@ -50,9 +50,6 @@ public class Robot extends IterativeRobot {
 		
 		SmartDashboard.putData("Auto mode", chooser);
 		SmartDashboard.putData(new Climb(0.5));
-
-		
-		
 	}
 
 	/**

--- a/src/org/robockets/steamworks/RobotMap.java
+++ b/src/org/robockets/steamworks/RobotMap.java
@@ -1,8 +1,10 @@
 package org.robockets.steamworks;
 
 import edu.wpi.first.wpilibj.Encoder;
+import edu.wpi.first.wpilibj.PowerDistributionPanel;
 import edu.wpi.first.wpilibj.RobotDrive;
 import edu.wpi.first.wpilibj.TalonSRX;
+import edu.wpi.first.wpilibj.Victor;
 
 /**
  * The RobotMap is a mapping from the ports sensors and actuators are wired into
@@ -32,4 +34,10 @@ public class RobotMap {
     public static Encoder backRightEncoder = new Encoder(PortNumbers.DRIVETRAIN_BACK_RIGHT_ENCODER_PORT_ONE, PortNumbers.DRIVETRAIN_BACK_RIGHT_ENCODER_PORT_TWO);
 
     public static RobotDrive robotDrive = new RobotDrive(frontLeftSpeedController, backLeftSpeedController, frontRightSpeedController, backRightSpeedController);
+    
+    public static PowerDistributionPanel powerDistPanel = new PowerDistributionPanel(); // Please note that this must be CAN id 0.
+
+    // Climber related.
+    
+    public static Victor climberMotor = new Victor(PortNumbers.CLIMBER_SC_PORT); // TODO: Match actual hardware.
 }

--- a/src/org/robockets/steamworks/commands/Climb.java
+++ b/src/org/robockets/steamworks/commands/Climb.java
@@ -1,0 +1,57 @@
+package org.robockets.steamworks.commands;
+
+import org.robockets.steamworks.Robot;
+import org.robockets.steamworks.subsystems.Climber;
+
+import edu.wpi.first.wpilibj.command.Command;
+
+public class Climb extends Command {
+
+	double time;
+	double speed;
+	boolean climbWithTime = false; // Determines isFinished. Will the command use time?
+	
+	/**
+	 * Climb a rope until the motor stalls signaling hitting the button.
+	 * @param speed		The speed to climb the rope in.
+	 */
+	public Climb (double speed) {
+		requires(Robot.climber);
+		this.speed = speed;
+	}
+	
+	/**
+	 * Climb a rope given a certain time interval.
+	 * @param time		The time, in seconds, to stall the motor for. Set the time to zero to run it indefinitely. 
+	 */
+	public Climb (double speed, double time) {
+		this(speed);
+		this.time = time;
+		climbWithTime = true;
+	}
+	
+	protected void initialize() {
+		if (climbWithTime == true && time != 0) {
+			setTimeout(time);
+		}
+		Robot.climber.setMotor(speed);
+	}
+	
+	protected boolean isFinished() {
+		if (climbWithTime == true && time != 0) { // The case that the command runs within a certain time.
+			return isTimedOut(); 
+		} else if (climbWithTime == false) { // The case that the command runs until the motor stalls.
+			return Robot.climber.readCurrent() > Climber.STALLING_THRESHOLD;
+		}									
+		return false; // The case that the command runs indefinitely.
+	}
+	
+	protected void interrupted() {
+		end();
+	}
+	
+	protected void end() {
+		Robot.climber.setMotor(0); // Brake the motor.
+	}
+
+}

--- a/src/org/robockets/steamworks/commands/Climb.java
+++ b/src/org/robockets/steamworks/commands/Climb.java
@@ -7,13 +7,13 @@ import edu.wpi.first.wpilibj.command.Command;
 
 public class Climb extends Command {
 
-	double time;
-	double speed;
-	boolean climbWithTime = false; // Determines isFinished. Will the command use time?
+	private double time;
+	private double speed;
+	private boolean climbWithTime = false; // Determines isFinished. Will the command use time?
 	
 	/**
 	 * Climb a rope until the motor stalls signaling hitting the button.
-	 * @param speed		The speed to climb the rope in.
+	 * @param speed	The speed to climb the rope in.
 	 */
 	public Climb (double speed) {
 		requires(Robot.climber);
@@ -22,7 +22,7 @@ public class Climb extends Command {
 	
 	/**
 	 * Climb a rope given a certain time interval.
-	 * @param time		The time, in seconds, to stall the motor for. Set the time to zero to run it indefinitely. 
+	 * @param time The time, in seconds, to stall the motor for. Set the time to zero to run it indefinitely.
 	 */
 	public Climb (double speed, double time) {
 		this(speed);
@@ -34,13 +34,17 @@ public class Climb extends Command {
 		if (climbWithTime == true && time != 0) {
 			setTimeout(time);
 		}
+	}
+
+	@Override
+	protected void execute() {
 		Robot.climber.setMotor(speed);
 	}
-	
+
 	protected boolean isFinished() {
-		if (climbWithTime == true && time != 0) { // The case that the command runs within a certain time.
+		if (climbWithTime && time != 0) { // The case that the command runs within a certain time.
 			return isTimedOut(); 
-		} else if (climbWithTime == false) { // The case that the command runs until the motor stalls.
+		} else if (!climbWithTime) { // The case that the command runs until the motor stalls.
 			return Robot.climber.readCurrent() > Climber.STALLING_THRESHOLD;
 		}									
 		return false; // The case that the command runs indefinitely.

--- a/src/org/robockets/steamworks/subsystems/Climber.java
+++ b/src/org/robockets/steamworks/subsystems/Climber.java
@@ -1,0 +1,31 @@
+package org.robockets.steamworks.subsystems;
+
+import org.robockets.steamworks.PortNumbers;
+import org.robockets.steamworks.RobotMap;
+
+import edu.wpi.first.wpilibj.command.Subsystem;
+
+public class Climber extends Subsystem{
+
+	public static final double  STALLING_THRESHOLD = 12; // The stalling current of the subsystem motor.
+	
+	/**
+	 * Read the current that the motor of the climber is using.
+	 * @return current		The current of the motor.	
+	 */
+	public double readCurrent() {
+		return RobotMap.powerDistPanel.getCurrent(PortNumbers.CLIMBER_PDP_PORT);
+	}
+	
+	/**
+	 * Set the motor speed.
+	 * @param speed 	A double (0-1) describing the speed to set the motor at. 
+	 */
+	public void setMotor(double speed) {
+		RobotMap.climberMotor.set(speed);
+	}
+	
+	public void initDefaultCommand() {
+
+	}
+}

--- a/src/org/robockets/steamworks/subsystems/Climber.java
+++ b/src/org/robockets/steamworks/subsystems/Climber.java
@@ -7,7 +7,7 @@ import edu.wpi.first.wpilibj.command.Subsystem;
 
 public class Climber extends Subsystem{
 
-	public static final double  STALLING_THRESHOLD = 12; // The stalling current of the subsystem motor.
+	public static final double STALLING_THRESHOLD = 12; // The stalling current of the subsystem motor.
 	
 	/**
 	 * Read the current that the motor of the climber is using.


### PR DESCRIPTION
I added a climber subsystem. The motor used is undefined so far.
The port numbers for the motor, and the motor's connection to the PDP need to
be changed. In addition the stalling threshold of the motor needs to be changed after testing.

The reason the climb command has a speed parameter is that I believe the Robot
should fetch how much time is left in the match to decide how fast it should
climb the rope. So whatever calls the Climb command needs to use this.